### PR TITLE
Run on all trees; fit changes

### DIFF
--- a/training/DeepCore_GPU.py
+++ b/training/DeepCore_GPU.py
@@ -751,7 +751,7 @@ if TRAIN :
         ## chaning steps_per_epoch=stepNum/20 to steps_per_epoch=stepNum
         #history = model.fit_generator(generator=Generator(files),steps_per_epoch=stepNum, epochs=epochs+start_epoch, verbose = 2, max_queue_size=1, validation_data=Generator(files_validation),  validation_steps=jetNum_validation/batch_
         
-        history = model.fit(Generator2(trainingpath,batch_size),steps_per_epoch=int(stepNum)/20, epochs=args.Epochs,use_multiprocessing=True,workers=5, verbose = 2, max_queue_size=5,  validation_data=Generator2(validationpath,batch_size),  validation_steps=int(jetNum_validation/batch_size), initial_epoch=start_epoch, callbacks=[checkpointer]) 
+        history = model.fit(Generator2(trainingpath,batch_size),steps_per_epoch=int(stepNum)/20, epochs=start_epoch+args.Epochs,use_multiprocessing=True,workers=5, verbose = 2, max_queue_size=5,  validation_data=Generator2(validationpath,batch_size),  validation_steps=int(jetNum_validation/batch_size), initial_epoch=start_epoch, callbacks=[checkpointer]) 
         print("done running; now save")
         
     model.save_weights('DeepCore_train_ev{ev}_ep{ep}.h5'.format(ev=jetNum, ep=epochs+start_epoch))

--- a/training/DeepCore_GPU.py
+++ b/training/DeepCore_GPU.py
@@ -750,7 +750,7 @@ if TRAIN :
         ## chaning steps_per_epoch=stepNum/20 to steps_per_epoch=stepNum
         #history = model.fit_generator(generator=Generator(files),steps_per_epoch=stepNum, epochs=epochs+start_epoch, verbose = 2, max_queue_size=1, validation_data=Generator(files_validation),  validation_steps=jetNum_validation/batch_
         
-        history = model.fit(Generator2(trainingpath,batch_size),steps_per_epoch=int(stepNum)/20, epochs=args.Epochs, verbose = 2, max_queue_size=5,  validation_data=Generator2(validationpath,batch_size),  validation_steps=int(jetNum_validation/batch_size), initial_epoch=start_epoch, callbacks=[checkpointer]) 
+        history = model.fit(Generator2(trainingpath,batch_size),steps_per_epoch=int(stepNum)/20, epochs=args.Epochs,use_multiprocessing=True,workers=5, verbose = 2, max_queue_size=5,  validation_data=Generator2(validationpath,batch_size),  validation_steps=int(jetNum_validation/batch_size), initial_epoch=start_epoch, callbacks=[checkpointer]) 
         print("done running; now save")
         
     model.save_weights('DeepCore_train_ev{ev}_ep{ep}.h5'.format(ev=jetNum, ep=epochs+start_epoch))


### PR DESCRIPTION
The new generator (using uproot4!) is added and validated. I've left uproot3 and the old generator in case for compatibility but we should delete them eventually.  Input samples are specified with `trainingpath` and `validationpath` instead of the fileglobs for the new generator. (You'll need to change these to your sample location on gpu1. I didn't see them after a brief look.)

I also modified the fit details in a few ways. First, model.fit_generator is getting deprecated, and using model.fit was a simple-enough change. To avoid the loss function going to NaN (presumably from exploding gradients due to weird/tricky clusters), I switched  `loss_ROIsoft_crossentropy` to `loss_ROI_crossentropy` (which is what Valerio did for early trainings anyway).  This was much more relevant when using all 8 trees per file. I added 5 worker processes to help feed data from disk to the GPU and this seemed to help performance significantly. Previously, training 1 epoch on one tree from each file took 5 minutes. Now, it takes under two. Lastly, I set the epoch numbering back to int(stepnum)/20. I think this will be more convenient for following Valerio's changes to the learning rate and loss function in the next training.

Let me know what you think.