### PR TITLE
Save pb file via TF1 graph; add script to dump pb contents

### DIFF
--- a/keras_to_TF/explore.py
+++ b/keras_to_TF/explore.py
@@ -1,0 +1,23 @@
+#import tensorflow as tf
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+
+
+import sys
+import tensorflow.compat.v1 as tf
+from tensorflow.python.platform import gfile
+
+f = sys.argv[1]
+GRAPH_PB_PATH = f
+with tf.Session() as sess:
+   print("load graph")
+   with gfile.FastGFile(GRAPH_PB_PATH,'rb') as f:
+       graph_def = tf.GraphDef()
+   graph_def.ParseFromString(f.read())
+   sess.graph.as_default()
+   tf.import_graph_def(graph_def, name='')
+   graph_nodes=[n for n in graph_def.node]
+   names = []
+   for t in graph_nodes:
+      names.append(t.name)
+   print(names)

--- a/keras_to_TF/keras_to_tensorflow_custom_GPU.py
+++ b/keras_to_TF/keras_to_tensorflow_custom_GPU.py
@@ -1,195 +1,55 @@
 from __future__ import print_function
-
-# coding: utf-8
-
-# In[ ]:
-
-"""
-Copyright (c) 2017, by the Authors: Amir H. Abdi
-This software is freely available under the MIT Public License.
-Please see the License file in the root for details.
-
-The following code snippet will convert the keras model file,
-which is saved using model.save('kerasmodel_weight_file'),
-to the freezed .pb tensorflow weight file which holds both the
-network architecture and its associated weights.
-""";
-
-
-# In[ ]:
-
-'''
-Input arguments:
-
-num_output: this value has nothing to do with the number of classes, batch_size, etc.,
-and it is mostly equal to 1. If the network is a **multi-stream network**
-(forked network with multiple outputs), set the value to the number of outputs.
-
-quantize: if set to True, use the quantize feature of Tensorflow
-(https://www.tensorflow.org/performance/quantization) [default: False]
-
-use_theano: Thaeno and Tensorflow implement convolution in different ways.
-When using Keras with Theano backend, the order is set to 'channels_first'.
-This feature is not fully tested, and doesn't work with quantizization [default: False]
-
-input_fld: directory holding the keras weights file [default: .]
-
-output_fld: destination directory to save the tensorflow files [default: .]
-
-input_model_file: name of the input weight file [default: 'model.h5']
-
-output_model_file: name of the output weight file [default: args.input_model_file + '.pb']
-
-graph_def: if set to True, will write the graph definition as an ascii file [default: False]
-
-output_graphdef_file: if graph_def is set to True, the file name of the
-graph definition [default: model.ascii]
-
-output_node_prefix: the prefix to use for output nodes. [default: output_node]
-
-'''
-
-
-# Parse input arguments
-
-# In[ ]:
-
-
-
-
-
 import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "_1"
 ## moved earlier
-import tensorflow as tf
-
+## try this
+##from keras.backend import tensorflow_backend as K
+##import tensorflow as tf
+from  matplotlib import pyplot as plt
+from array import array as array2
 from keras.callbacks import Callback
-
+from keras.callbacks import ModelCheckpoint
+from keras.initializers import *
+from keras.layers import AlphaDropout
+from keras.layers import Input, LSTM, Dense, Flatten, Conv2D, MaxPooling2D, Dropout, Reshape, Conv2DTranspose, concatenate, Concatenate, ZeroPadding2D, UpSampling2D, UpSampling1D
 from keras.models import Model,load_model, Sequential
 
-from keras.layers import Input, LSTM, Dense, Flatten, Conv2D, MaxPooling2D, Dropout, Reshape, Conv2DTranspose, concatenate, Concatenate, ZeroPadding2D, UpSampling2D, UpSampling1D
+
 
 from keras.optimizers import *
-
-from keras.initializers import *
-
-import numpy as np
-
-##import tensorflow as tf
-
-##from keras.backend import tensorflow_backend as K
-## try this
-import tensorflow.keras.backend as K
-
-import keras
-
-import math
-
-import sys
-
-import argparse
-
-import matplotlib as mpl
-
-import matplotlib.backends.backend_pdf as backpdf
-
-from keras.callbacks import ModelCheckpoint
-
-from  matplotlib import pyplot as plt
-
-import pylab
-
-import glob
-
-from tensorflow.python.framework import ops
-
-from tensorflow.python.ops import clip_ops
-
-from tensorflow.python.ops import math_ops
-
-from tensorflow.python.ops import nn
-
 from numpy import concatenate as concatenatenp
-
-import random
-
-import uproot
-
-
-import gzip
-import pickle
-
-
-
-
-import uproot
-
-from keras.layers import AlphaDropout
-
-import uproot
-
-
-
-from array import array as array2
-
-
-
-
-
-
-import argparse
-parser = argparse.ArgumentParser(description='set input arguments')
-parser.add_argument('-input_fld', action="store",
-                    dest='input_fld', type=str, default='.')
-parser.add_argument('-output_fld', action="store",
-                    dest='output_fld', type=str, default='')
-parser.add_argument('-input_model_file', action="store",
-                    dest='input_model_file', type=str, default='model.h5')
-parser.add_argument('-output_model_file', action="store",
-                    dest='output_model_file', type=str, default='')
-parser.add_argument('-output_graphdef_file', action="store",
-                    dest='output_graphdef_file', type=str, default='model.ascii')
-parser.add_argument('-num_outputs', action="store",
-                    dest='num_outputs', type=int, default=2)
-parser.add_argument('-graph_def', action="store",
-                    dest='graph_def', type=bool, default=False)
-parser.add_argument('-output_node_prefix', action="store",
-                    dest='output_node_prefix', type=str, default='output_node')
-parser.add_argument('-quantize', action="store",
-                    dest='quantize', type=bool, default=False)
-parser.add_argument('-theano_backend', action="store",
-                    dest='theano_backend', type=bool, default=False)
-parser.add_argument('-f')
-args = parser.parse_args()
-parser.print_help()
-print('input args: ', args)
-
-if args.theano_backend is True and args.quantize is True:
-    raise ValueError("Quantize feature does not work with theano backend.")
-
-
-# initialize
-
-# In[ ]:
-
-from keras.models import load_model
-import tensorflow as tf
 from pathlib import Path
-from keras import backend as K
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+import argparse
+import argparse
+import glob
+import gzip
+import keras
+import math
+import matplotlib as mpl
+import matplotlib.backends.backend_pdf as backpdf
+import numpy as np
+import pickle
+import pylab
+import random
+import sys
+import tensorflow as tf
+import tensorflow.keras.backend as K
+import uproot
+import uproot
+import uproot
+import pdb
+#from keras import backend as K
 # import keras
 # from tensorflow.python.framework import ops
 
 
+tf.compat.v1.disable_eager_execution()
 
-output_fld =  args.input_fld if args.output_fld == '' else args.output_fld
-if args.output_model_file == '':
-    args.output_model_file = str(Path(args.input_model_file).name) + '.pb'
-##Path(output_fld).mkdir(parents=True)#, exist_ok=True)
-##weight_file_path = str(Path(args.input_fld) / args.input_model_file)
-weight_file_path = '/uscms_data/d3/hichemb/princeton/project2/CMSSW_10_2_5/src/DeepCore/keras_to_TF/DeepCore_model_0302_252.h5'
-
-# Load keras model and rename output
-
-# In[ ]:
+weight_file_path = sys.argv[1]
 
 def _to_tensor(x, dtype):
     return ops.convert_to_tensor(x, dtype=dtype)
@@ -232,14 +92,13 @@ def loss_ROIsoft_crossentropy(target, output):
     return tf.reduce_sum(retval, axis=None)/(tf.reduce_sum(wei,axis=None))
 
 K.set_learning_phase(0)
-if args.theano_backend:
-    K.set_image_data_format('channels_first')
-else:
-    K.set_image_data_format('channels_last')
+K.set_image_data_format('channels_last')
 
 try:
     ##net_model = load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROIsoft_crossentropy':loss_ROI_crossentropy, '_to_tensor':_to_tensor})
-    net_model = load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROI_crossentropy':loss_ROI_crossentropy, '_to_tensor':_to_tensor})
+    #net_model = load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROI_crossentropy':loss_ROI_crossentropy, '_to_tensor':_to_tensor})
+    net_model = tf.compat.v1.keras.models.load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROI_crossentropy':loss_ROI_crossentropy, '_to_tensor':_to_tensor})
+    #pdb.set_trace()
 except ValueError as err:
     print('''Input file specified ({}) only holds the weights, and not the model defenition.
     Save the model using mode.save(filename.h5) which will contain the network architecture
@@ -249,26 +108,33 @@ except ValueError as err:
     Check the keras documentation for more details (https://keras.io/getting-started/faq/)'''
           .format(weight_file_path))
     raise err
-net_model.save('test')
-num_output = args.num_outputs
+
+#net_model.save('test')
+num_output = 2
 pred = [None]*num_output
-pred_node_names = [None]*num_output
-for i in range(num_output):
-    pred_node_names[i] = args.output_node_prefix+str(i)
-    pred[i] = tf.identity(net_model.outputs[i], name=pred_node_names[i])
-print('output nodes names are: ', pred_node_names)
+#pred_node_names = [None]*num_output
+#for i in range(num_output):
+#    pred_node_names[i] = "output_node"+str(i)
+
+#outputNodeNames = ["reshape_1/Reshape:0","reshape_2/Reshape:0"]
+outputNodeNames = ["reshape_1_1","reshape_2_1"]
+#outputNodeNames = ["reshape_1/Reshape","reshape_2/Reshape"]
+for i,outputNodeName in enumerate(outputNodeNames):
+    #pdb.set_trace()
+    print(i,outputNodeName)
+    pred[i] = tf.identity(net_model.outputs[i], name=outputNodeName)
+#pdb.set_trace()
+print('output nodes names are: ', outputNodeNames)
 
 
-# [optional] write graph definition in ascii
+#sess = K.get_session()
+tf.compat.v1.disable_eager_execution()
+sess = tf.compat.v1.Session()
 
-# In[ ]:
-
-sess = K.get_session()
-
-if args.graph_def:
-    f = args.output_graphdef_file
-    tf.train.write_graph(sess.graph.as_graph_def(), output_fld, f, as_text=True)
-    print('saved the graph definition in ascii format at: ', str(Path(output_fld) / f))
+#if args.graph_def:
+#    f = args.output_graphdef_file
+#    tf.train.write_graph(sess.graph.as_graph_def(), output_fld, f, as_text=True)
+#    print('saved the graph definition in ascii format at: ', str(Path(output_fld) / f))
 
 
 # convert variables to constants and save
@@ -281,13 +147,11 @@ if args.graph_def:
 from tensorflow.compat.v1 import graph_util
 from tensorflow.python.framework import graph_io
 
-if args.quantize:
-    from tensorflow.tools.graph_transforms import TransformGraph
-    transforms = ["quantize_weights", "quantize_nodes"]
-    transformed_graph_def = TransformGraph(sess.graph.as_graph_def(), [], pred_node_names, transforms)
-    constant_graph = graph_util.convert_variables_to_constants(sess, transformed_graph_def, pred_node_names)
-else:
-    ##constant_graph = graph_util.convert_variables_to_constants(sess, sess.graph.as_graph_def(), pred_node_names)
-    constant_graph = graph_util.extract_sub_graph(sess.graph.as_graph_def(), pred_node_names)
-graph_io.write_graph(constant_graph, output_fld, args.output_model_file, as_text=False)
-print('saved the freezed graph (ready for inference) at: ', str(Path(output_fld) / args.output_model_file))
+#constant_graph = tf.compat.v1.graph_util.extract_sub_graph(sess.graph.as_graph_def(), pred_node_names)
+#pdb.set_trace()
+print(sess.graph.as_graph_def())
+output_fld = "pb_files"
+output_name = sys.argv[1].replace(".h5",".pb")
+constant_graph = tf.compat.v1.graph_util.extract_sub_graph(sess.graph.as_graph_def(), outputNodeNames)
+graph_io.write_graph(constant_graph, output_fld, output_name, as_text=False)
+print('saved the freezed graph (ready for inference) at: ', str(Path(output_fld) / output_name))


### PR DESCRIPTION
`python keras_to_tensorflow_custom_GPU.py DeepCore_model_0302_252.h5` now makes a pb file that is compatible with loading via tf1 graphs (`python explore.py DeepCoreSeedGenerator_TrainedModel_barrel_2017.pb`). The output node names from the keras model are reshape_1 and reshape_2, but in the tensorflow graph they seem to become reshape_1_1 and reshape_2_1.