### PR TITLE
h5_to_pb fix

### DIFF
--- a/Convert_h5_to_pb/h5_to_pb.py
+++ b/Convert_h5_to_pb/h5_to_pb.py
@@ -1,55 +1,27 @@
 from __future__ import print_function
-
-
-
 import os
-
 # ran without problems on fermilab gpu server singularity environment
 # (tensorflow 2)
 
+import numpy as np
 import tensorflow as tf
 if tf.__version__.startswith("2."):
   tf = tf.compat.v1
 tf.disable_eager_execution()
-
 import keras
-
-
 import math
-
 import sys
-
 import argparse
-
-
 from keras.callbacks import ModelCheckpoint
-
 from  matplotlib import pyplot as plt
-
 import pylab
-
 import glob
-
 from tensorflow.python.framework import ops
-
 from tensorflow.python.ops import clip_ops
-
 from tensorflow.python.ops import math_ops
-
 from tensorflow.python.ops import nn
 
-from numpy import concatenate as concatenatenp
-
-import random
-
-
-
-from keras.layers import AlphaDropout
-
-
-
 from keras import backend as K
-
 from keras.models import load_model
 
 # adjust input file (h5) path here
@@ -73,7 +45,7 @@ def loss_mse_select_clipped(y_true, y_pred) :
   # Valerio here multplied denominator by 4 and does not add 0.00001, which is what he did during the training, so the loss function here is not defined correctly
   # return tf.reduce_sum(out, axis=None)/(tf.reduce_sum(wei,axis=None)*4) #4=numPar
   # Fixed
-  return tf.reduce_sum(out, axis=None)/(tf.reduce_sum(wei,axis=None)*5 + 0.00001) #4=numPar
+    return tf.reduce_sum(out, axis=None)/(tf.reduce_sum(wei,axis=None)*5 + 0.00001) #4=numPar
 
 def loss_ROI_crossentropy(target, output):
     epsilon_ = _to_tensor(keras.backend.epsilon(), output.dtype.base_dtype)
@@ -117,9 +89,13 @@ def loss_ROIsoft_crossentropy(target, output):
 # wrong, also it's not loading epsilon function
 # net_model = load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROIsoft_crossentropy':loss_ROI_crossentropy, '_to_tensor':_to_tensor})
 # Fixed: if last loss function used is ROIsoft, use this
+sess = tf.Session()
+K.set_session(sess)
+K.set_learning_phase(0)
 net_model = load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROIsoft_crossentropy':loss_ROIsoft_crossentropy, '_to_tensor':_to_tensor, 'epsilon': epsilon})
-# If last loss function used is ROI, use this
-# net_model = load_model(weight_file_path,custom_objects={'loss_mse_select_clipped':loss_mse_select_clipped,'loss_ROI_crossentropy':loss_ROI_crossentropy, '_to_tensor':_to_tensor, 'epsilon':epsilon})
+#predict test case for validation
+print(net_model.predict([np.array([30*[30*[[0]*4]]],dtype=float),np.array([0],dtype=float),np.array([0],dtype=float)]))
+
 
 # renaming output nodes
 num_output = 2
@@ -129,9 +105,6 @@ for i in range(num_output):
       pred_node_names[i] = "output_node"+str(i)
       pred[i] = tf.identity(net_model.outputs[i], name=pred_node_names[i])
 print('output nodes names are: ', pred_node_names)
-
-sess = tf.Session()
-sess.run(tf.global_variables_initializer())
 
 outputs = pred_node_names 
 

--- a/Convert_h5_to_pb/testPB.py
+++ b/Convert_h5_to_pb/testPB.py
@@ -1,0 +1,32 @@
+import numpy as np
+import tensorflow.compat.v1 as tf
+import sys
+tf.disable_eager_execution()
+
+sess = tf.Session()
+
+with tf.gfile.GFile(sys.argv[1],"rb") as f:
+    graph_def = tf.GraphDef()
+    graph_def.ParseFromString(f.read())
+    graph = tf.Graph().as_default()
+    sess.graph.as_default()
+
+    tf.import_graph_def(graph_def,name='')
+
+tensor_input_1 = sess.graph.get_tensor_by_name('input_1:0')
+tensor_input_2 = sess.graph.get_tensor_by_name('input_2:0')
+tensor_input_3 = sess.graph.get_tensor_by_name('input_3:0')
+tensor_output_1 = sess.graph.get_tensor_by_name('output_node0:0')
+tensor_output_2 = sess.graph.get_tensor_by_name('output_node1:0')
+
+tensor_output = [tensor_output_1,tensor_output_2]
+tfPar,tfProb = sess.run(tensor_output, {tensor_input_1: [[0]], tensor_input_2:[[0]], tensor_input_3: [30*[30*[[0]*4]]]})
+print(tfProb)
+
+#Alternatively, can test h5 model with these lines
+#import keras
+#keras = tf.keras
+#weight_file = "../Training0628/DeepCore_model_0628.h5"
+#kmodel = keras.models.load_model(weight_file,custom_objects={'loss_mse_select_clipped': (lambda x,x1 : x),'loss_ROIsoft_crossentropy': (lambda y,y1 : y), '_to_tensor': (lambda z : z), 'epsilon': 0})
+#a=kmodel.predict([np.array([30*[30*[[0]*4]]],dtype=float),np.array([0],dtype=float),np.array([0],dtype=float)])
+#print(a)


### PR DESCRIPTION
By evaluating the pb and h5 models on a test case (all inputs=0), it was clear there was a discrepancy between the two methods. The key lines to the fix are 
```
sess = tf.Session()
K.set_session(sess)
K.set_learning_phase(0)
```
to ensure the Keras and TF sessions are synchronized and removing the later lines
```
sess = tf.Session()
sess.run(tf.global_variables_initializer())
```
where a non-Keras session was created and random weights are created.

`h5_to_pb.py` now prints out the validation zero-event, and `testPB.py` can be run on the protobuf file to verify the output matches.